### PR TITLE
fix: load story hub images relative

### DIFF
--- a/eds/blocks/related-stories/related-stories.js
+++ b/eds/blocks/related-stories/related-stories.js
@@ -37,10 +37,11 @@ function createCard(article, firstCard = false) {
       minRead = ` | ${article.readingTime} mins read`;
       break;
   }
+  const imageUrl = new URL(article.image, window.location);
 
   const cardWrapper = a(
     { class: 'group h-full', href: article.path, title: article.title },
-    imageHelper(article.image, article.title, firstCard),
+    imageHelper(imageUrl.pathname, article.title, firstCard),
     div(
       { class: 'py-2' },
       span({ class: 'capitalize font-normal text-sm' }, `${getStoryType(tags)}`),

--- a/eds/blocks/story-hub/story-hub.js
+++ b/eds/blocks/story-hub/story-hub.js
@@ -132,7 +132,7 @@ function handleRenderContent(newLists = lists) {
         footerLink = 'Read article';
         break;
     }
-    const imageUrl = new URL(article.image);
+    const imageUrl = new URL(article.image, window.location);
 
     cardList.appendChild(createCard({
       titleImage: imageHelper(imageUrl.pathname, article.title, (index === 0)),

--- a/eds/blocks/story-hub/story-hub.js
+++ b/eds/blocks/story-hub/story-hub.js
@@ -132,9 +132,10 @@ function handleRenderContent(newLists = lists) {
         footerLink = 'Read article';
         break;
     }
+    const imageUrl = new URL(article.image);
 
     cardList.appendChild(createCard({
-      titleImage: imageHelper(article.image, article.title, (index === 0)),
+      titleImage: imageHelper(imageUrl.pathname, article.title, (index === 0)),
       title: article.title,
       description: article.description,
       footerLink,


### PR DESCRIPTION
Load images domain relative (src starting with `/`) for images referenced from indexes. 

Check the cards in the stroy hub bock and the related stories block.

Test URLs:
- Before: https://main--danaher-abcam--aemsites.aem.live/en-us/stories
- After: https://story-hub-rel-images--danaher-abcam--aemsites.aem.live/en-us/stories
- Before: https://main--danaher-abcam--aemsites.aem.page/en-us/stories/films/robert-blelloch
- After: https://story-hub-rel-images--danaher-abcam--aemsites.aem.page/en-us/stories/films/robert-blelloch
