### PR TITLE
297 [Guides] Missing 'en-us' in the breadcrumb url

### DIFF
--- a/eds/blocks/breadcrumb/breadcrumb.js
+++ b/eds/blocks/breadcrumb/breadcrumb.js
@@ -2,14 +2,17 @@ import { getMetadata } from '../../scripts/aem.js';
 import {
   div, nav, ul, li, a,
 } from '../../scripts/dom-builder.js';
-// breadcrumb functionality implementation
+
 export default function decorate(block) {
   const path = window.location.pathname.split('/').slice(2);
   const ogTitle = getMetadata('og:title');
   const title = ogTitle.indexOf('| abcam') > -1 ? ogTitle.split('| abcam')[0] : ogTitle;
-  const navigation = getMetadata('navigation');
-  if (navigation !== 'false' || navigation === null) {
-    const { length } = path;
+  const newUrl = new URL(window.location);
+  if (window.location.pathname.indexOf('technical-resources/guides') > -1) {
+    newUrl.pathname = window.location.pathname.substring(0, window.location.pathname.indexOf('/technical-resources/guides/'));
+  }
+  const { length } = path;
+  if (length > 0) {
     const breadcrumbLiLinks = li();
     let url = '';
     let breadcrumbLinks = '';
@@ -20,8 +23,8 @@ export default function decorate(block) {
       let link = i === length - 1 ? title : path[i].charAt(0).toUpperCase() + path[i].slice(1);
       link = link.toLowerCase().replace(/\b[a-z]/g, (letter) => letter.toUpperCase());
       if (i !== 0) link = ` / ${link}`;
-      if (i !== length - 1) breadcrumbLinks = a({ class: '\'breadcrumblink hover:underline  text-lg\'', href: url }, (`${link}`));
-      else { breadcrumbLinks = a({ class: '\'breadcrumblink underline text-lg\'', href: url }, (`${link}`)); }
+      if (i !== length - 1) breadcrumbLinks = a({ class: '\'breadcrumblink hover:underline  text-lg\'', href: newUrl + url }, (`${link}`));
+      else { breadcrumbLinks = a({ class: '\'breadcrumblink underline text-lg\'', href: newUrl + url }, (`${link}`)); }
       breadcrumbLiLinks.appendChild(breadcrumbLinks);
     }
     const breadcrumNav = nav(


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #297 

Test URLs:
- Before: https://main--danaher-abcam--aemsites.hlx.live/en-us
- After: https://297-breadcrumb-url-fix--danaher-abcam--aemsites.hlx.live/en-us/technical-resources/guides/cell-death-guide
