### PR TITLE
added sticky0right-navigation component in guide template

### DIFF
--- a/eds/templates/guide/guide.js
+++ b/eds/templates/guide/guide.js
@@ -10,6 +10,9 @@ export default async function buildAutoBlocks() {
   sectionMiddle.prepend(
     buildBlock('chapter-links', { elems: [] }),
   );
+  sectionMiddle.prepend(
+    buildBlock('sticky-right-navigation', { elems: [] }),
+  );
   const headerSection = div();
   const breadcrumbBlock = buildBlock('breadcrumb', { elems: [] });
   headerSection.append(breadcrumbBlock);


### PR DESCRIPTION
Fix #269 

Test URLs:
- Before: https://main--danaher-abcam--aemsites.hlx.live/en-us/technical-resources/guides/cell-death-guide
- After:  https://269-guide-template--danaher-abcam--aemsites.hlx.live/en-us/technical-resources/guides/cell-death-guide)
