### PR TITLE
315 [Guides] Chapters should be listed in custom sort order

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -583,15 +583,15 @@
           }
         },
         {
-          "title": "Sticky Right Navigation",
-          "id": "sticky-right-navigation",
+          "title": "Sticky Sections List",
+          "id": "sticky-sections-list",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Sticky Right Navigation",
-                  "model": "sticky-right-navigation"
+                  "name": "Sticky Sections List",
+                  "model": "sticky-sections-list"
                 }
               }
             }

--- a/component-filters.json
+++ b/component-filters.json
@@ -43,8 +43,7 @@
       "story-hub",
       "speakers-info",
       "download",
-      "table",
-      "sticky-sections-list"
+      "table"
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -77,6 +77,12 @@
             "valueType": "string",
             "name": "template",
             "label": "Template"
+          },
+          {
+            "component": "text",
+            "valueType": "number",
+            "name": "pageOrder",
+            "label": "Page Order"
           }
         ]
       }

--- a/eds/blocks/chapter-links/chapter-links.css
+++ b/eds/blocks/chapter-links/chapter-links.css
@@ -211,6 +211,10 @@
   padding-right: 1.5rem
 }
 
+.chapter-links-wrapper :is(.pt-6) {
+  padding-top: 1.5rem
+}
+
 .chapter-links-wrapper :is(.text-sm) {
   font-size: 0.875rem;
   line-height: 1.25rem

--- a/eds/blocks/chapter-links/chapter-links.js
+++ b/eds/blocks/chapter-links/chapter-links.js
@@ -86,7 +86,7 @@ export default async function decorate(block) {
     path: element.path,
   }));
   const filteredChapters = chapters.filter((item) => item.title !== undefined);
-  filteredChapters.sort((chapter1, chapter2) => chapter1.pageOrder.toString().localeCompare(chapter2.pageOrder.toString(), undefined, { numeric: true }));
+  filteredChapters.sort((chapter1, chapter2) => chapter1.pageOrder - chapter2.pageOrder);
 
   // Append button and chapters to block
   const { chaptersDesktopDiv, chaptersMobileDiv } = renderChapters(filteredChapters);

--- a/eds/blocks/chapter-links/chapter-links.js
+++ b/eds/blocks/chapter-links/chapter-links.js
@@ -82,11 +82,11 @@ export default async function decorate(block) {
     .all();
   const chapters = chapterItems.map((element) => ({
     title: element.title.indexOf('| abcam') > -1 ? element.title.split('| abcam')[0] : element.title,
-    description: element.description,
+    pageOrder: element.pageOrder,
     path: element.path,
   }));
   const filteredChapters = chapters.filter((item) => item.title !== undefined);
-  filteredChapters.sort((chapter1, chapter2) => chapter1.title.localeCompare(chapter2.title));
+  filteredChapters.sort((chapter1, chapter2) => chapter2.pageOrder - chapter1.pageOrder);
 
   // Append button and chapters to block
   const { chaptersDesktopDiv, chaptersMobileDiv } = renderChapters(filteredChapters);

--- a/eds/blocks/chapter-links/chapter-links.js
+++ b/eds/blocks/chapter-links/chapter-links.js
@@ -86,7 +86,7 @@ export default async function decorate(block) {
     path: element.path,
   }));
   const filteredChapters = chapters.filter((item) => item.title !== undefined);
-  filteredChapters.sort((chapter1, chapter2) => chapter2.pageOrder - chapter1.pageOrder);
+  filteredChapters.sort((chapter1, chapter2) => chapter1.pageOrder.toString().localeCompare(chapter2.pageOrder.toString(), undefined, { numeric: true }));
 
   // Append button and chapters to block
   const { chaptersDesktopDiv, chaptersMobileDiv } = renderChapters(filteredChapters);

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -62,4 +62,7 @@ indices:
       parent:
         select: head > meta[property="og:url"]
         value: match(attribute(el, "content"), "\/([^\/]+)\/[^\/]+$")
+      pageOrder:
+        select: head > meta[name="pageorder"]
+        value: attribute(el, "content")
 

--- a/models/_page-metadata.json
+++ b/models/_page-metadata.json
@@ -78,7 +78,13 @@
                     "valueType": "string",
                     "name": "template",
                     "label": "Template"
-                  }
+                  },
+                  {
+                    "component": "text",
+                    "valueType": "number",
+                    "name": "pageOrder",
+                    "label": "Page Order"
+                  }                  
                 ]
               }
             ]


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #315 

Test URLs:
- Before: https://main--danaher-abcam--aemsites.hlx.live/en-us
- After: https://315-chapters-custom-sort-order--danaher-abcam--aemsites.hlx.live/en-us/technical-resources/guides/elisa-guide

