### PR TITLE
402 [Stories] Podcast page issue fix after 'Title Card' removal

### DIFF
--- a/eds/templates/stories/stories.js
+++ b/eds/templates/stories/stories.js
@@ -4,9 +4,7 @@ import { buildArticleSchema, buildPodcastEpisodeSchema } from '../../scripts/sch
 export default async function buildAutoBlocks() {
   const main = document.querySelector('main');
   const sectionColumns = main.querySelector(':scope > div > div.columns')?.parentElement;
-  const sectionMiddle = getMetadata('pagetags').includes('podcast')
-    ? main.querySelector(':scope > div:nth-child(3)')
-    : main.querySelector(':scope > div:nth-child(2)');
+  const sectionMiddle = main.querySelector(':scope > div:nth-child(2)');
   sectionColumns.prepend(
     buildBlock('back-navigation', { elems: [] }),
   );


### PR DESCRIPTION
Fix for podcast issue

Fix #402 

Test URLs:
- Before: https://main--danaher-abcam--aemsites.aem.live/en-us/stories/podcasts/colliderscope-linda-griffith
- After: https://402-podcast-issue-fix--danaher-abcam--aemsites.aem.live/en-us/stories/podcasts/colliderscope-linda-griffith
