### PR TITLE
487- [Webinar] Breadcrumb 404 Issue

### DIFF
--- a/eds/blocks/breadcrumb/breadcrumb.js
+++ b/eds/blocks/breadcrumb/breadcrumb.js
@@ -9,11 +9,17 @@ export default function decorate(block) {
   const ogTitle = getMetadata('og:title');
   const title = (ogTitle.indexOf('| abcam') || ogTitle.indexOf('| Abcam')) > -1 ? (ogTitle.split('| abcam')[0] || ogTitle.split('| Abcam')[0]) : ogTitle;
   const newUrl = new URL(window.location);
-  if (pageUrl.indexOf('technical-resources/guides') > -1) {
-    newUrl.pathname = pageUrl.substring(0, pageUrl.indexOf('/technical-resources/'));
-  } else if (pageUrl.indexOf('/knowledge-center') > -1) {
-    newUrl.pathname = pageUrl.substring(0, pageUrl.indexOf('/knowledge-center/'));
+
+  const pathFragments = [
+    '/technical-resources/guides',
+    '/knowledge-center',
+    '/webinars',
+  ];
+  const matchingFragment = pathFragments.find((fragment) => pageUrl.includes(fragment));
+  if (matchingFragment) {
+    newUrl.pathname = pageUrl.substring(0, pageUrl.indexOf(matchingFragment));
   }
+
   const { length } = path;
   if (length > 0) {
     const breadcrumbLiLinks = li({ class: 'flex gap-x-2' });


### PR DESCRIPTION
Made it dynamic; new entries can be easily added to the array in the future.
Fix #487 

Test URLs:
- Before: https://main--danaher-abcam--aemsites.hlx.page/en-us/webinars/autophagy-and-neurodegeneration
- After: https://487-webinar-breadcrumb-issue--danaher-abcam--aemsites.hlx.page/en-us/webinars/autophagy-and-neurodegeneration
