### PR TITLE
496 [PostImp] The titles ending in '| Abcam' are showing

### DIFF
--- a/eds/blocks/breadcrumb/breadcrumb.js
+++ b/eds/blocks/breadcrumb/breadcrumb.js
@@ -2,12 +2,13 @@ import { getMetadata } from '../../scripts/aem.js';
 import {
   div, nav, ul, li, a,
 } from '../../scripts/dom-builder.js';
+import { removeAbcamTitle } from '../../scripts/scripts.js';
 
 export default function decorate(block) {
   const pageUrl = window.location.pathname;
   const path = pageUrl.split('/').slice(2);
   const ogTitle = getMetadata('og:title');
-  const title = (ogTitle.indexOf('| abcam') || ogTitle.indexOf('| Abcam')) > -1 ? (ogTitle.split('| abcam')[0] || ogTitle.split('| Abcam')[0]) : ogTitle;
+  const title = removeAbcamTitle(ogTitle);
   const newUrl = new URL(window.location);
 
   const pathFragments = [

--- a/eds/blocks/chapter-links/chapter-links.js
+++ b/eds/blocks/chapter-links/chapter-links.js
@@ -4,6 +4,7 @@ import {
 } from '../../scripts/dom-builder.js';
 import { decorateIcons } from '../../scripts/aem.js';
 import { buildArticleSchema, buildCollectionSchema } from '../../scripts/schema.js';
+import { removeAbcamTitle } from '../../scripts/scripts.js';
 
 const modal = div({ class: 'w-screen h-full top-0 left-0 fixed block lg:hidden inset-0 z-30 bg-black bg-opacity-80 flex justify-center items-end transition-all translate-y-full' });
 const stickyChapterLinks = div({ class: 'sticky-bottom' });
@@ -70,7 +71,7 @@ export default async function decorate(block) {
       return item.parent === parentPage;
     }).all();
   const chapters = chapterItems.map((element) => ({
-    title: (element.title.indexOf('| abcam') || element.title.indexOf('| Abcam')) > -1 ? (element.title.split('| abcam')[0] || element.title.split('| Abcam')[0]) : element.title,
+    title: removeAbcamTitle(element.title),
     pageOrder: element.pageOrder,
     path: element.path,
   }));

--- a/eds/blocks/dynamic-cards/articleCard.js
+++ b/eds/blocks/dynamic-cards/articleCard.js
@@ -1,5 +1,5 @@
 import {
-  formatDate, formatTime, getContentType, imageHelper,
+  formatDate, formatTime, getContentType, imageHelper, removeAbcamTitle
 } from '../../scripts/scripts.js';
 import {
   li, a, p, div, h3, span,
@@ -51,7 +51,7 @@ export default function createCard(article, firstCard = false, cardType = 'story
       titleImage,
       div(
         { class: 'flex-1' },
-        title && h3({ class: 'text-black font-medium mt-4 break-words line-clamp-4' }, title),
+        removeAbcamTitle(title) && h3({ class: 'text-black font-medium mt-4 break-words line-clamp-4' }, removeAbcamTitle(title)),
         description && p({ class: 'text-sm line-clamp-3' }, description),
       ),
       footerLink !== ''

--- a/eds/blocks/dynamic-cards/articleCard.js
+++ b/eds/blocks/dynamic-cards/articleCard.js
@@ -1,5 +1,5 @@
 import {
-  formatDate, formatTime, getContentType, imageHelper, removeAbcamTitle
+  formatDate, formatTime, getContentType, imageHelper, removeAbcamTitle,
 } from '../../scripts/scripts.js';
 import {
   li, a, p, div, h3, span,

--- a/eds/blocks/related-articles/related-articles.js
+++ b/eds/blocks/related-articles/related-articles.js
@@ -4,6 +4,7 @@ import {
 } from '../../scripts/dom-builder.js';
 import { decorateIcons, getMetadata } from '../../scripts/aem.js';
 import { renderChapters } from '../chapter-links/chapter-links.js';
+import { removeAbcamTitle } from '../../scripts/scripts.js';
 
 const modal = div({ class: 'w-screen h-full top-0 left-0 fixed block lg:hidden inset-0 z-30 bg-black bg-opacity-80 flex justify-center items-end transition-all translate-y-full' });
 const stickyChapterLinks = div({ class: 'sticky-bottom' });
@@ -37,7 +38,7 @@ export default async function decorate(block) {
     .filter((item) => item.tags && extractedTags.some((tag) => item.tags.includes(tag)))
     .all();
   const chapters = chapterItems.map((element) => ({
-    title: element.title.indexOf('| abcam') > -1 ? element.title.split('| abcam')[0] : element.title,
+    title: removeAbcamTitle(element.title),
     description: element.description,
     pageOrder: element.pageOrder,
     path: element.path,

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -880,6 +880,18 @@ export function formatDate(date) {
   return formatDate;
 }
 
+export function removeAbcamTitle(ogTitle){
+  let title;
+  if(ogTitle.indexOf('| abcam') > -1) {
+    title = ogTitle.split('| abcam')[0];
+  } else if(ogTitle.indexOf('| Abcam') > -1) {
+    title = ogTitle.split('| Abcam')[0];
+  } else {
+    title = ogTitle;
+  }
+  return title;
+}
+
 // Check if OneTrust is accepted
 export function isOTEnabled() {
   const otCookie = getCookie("OptanonConsent");


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #496 

Test URLs:
- Before: https://main--danaher-abcam--aemsites.aem.page/en-us/technical-resources/guides
- After: https://496-titles-ending-abcam--danaher-abcam--aemsites.aem.page/en-us/technical-resources/guides/antibody-basics/antibody-terms-glossary
- After: https://496-titles-ending-abcam--danaher-abcam--aemsites.aem.page/en-us/knowledge-center/cell-biology/exosomes
- After: https://496-titles-ending-abcam--danaher-abcam--aemsites.aem.page/en-us/knowledge-center
