### PR TITLE
Removed exclude paths from Abcam full index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -18,10 +18,6 @@ indices:
     include:
       - /en-us/**
     exclude:
-      - /en-us/stories
-      - /en-us/technical-resources/guides
-      - /en-us/knowledge-center
-      - /en-us/webinars
       - /en-us/stories/query-index.json
       - /en-us/technical-resources/guides/query-index.json
       - /en-us/knowledge-center/query-index.json


### PR DESCRIPTION
Test URLs:
Before: https://main--danaher-abcam--aemsites.hlx.live/
After: https://abcam-query-index--danaher-abcam--aemsites.hlx.page/en-us
