### PR TITLE
Updated index path to use related-articles-index

### DIFF
--- a/eds/blocks/related-articles/related-articles.js
+++ b/eds/blocks/related-articles/related-articles.js
@@ -33,7 +33,7 @@ export default async function decorate(block) {
   const extractedTags = kcTags.map((tag) => tag.split('/').pop());
   const title = getMetadata('og:title');
 
-  const chapterItems = await ffetch('/en-us/knowledge-center/query-index.json')
+  const chapterItems = await ffetch('/en-us/related-articles-index.json')
     .filter((item) => item.title && item.title !== title)
     .filter((item) => item.tags && extractedTags.some((tag) => item.tags.includes(tag)))
     .all();


### PR DESCRIPTION


Test URLs:
- Before: https://main--danaher-abcam--aemsites.hlx.page/en-us/knowledge-center/cell-biology/sodium-azide
- After: https://update-related-articles--danaher-abcam--aemsites.hlx.page/en-us/knowledge-center/cell-biology/sodium-azide
