### PR TITLE
Moved related-articles-index to eds folder

### DIFF
--- a/eds/blocks/related-articles/related-articles.js
+++ b/eds/blocks/related-articles/related-articles.js
@@ -33,7 +33,7 @@ export default async function decorate(block) {
   const extractedTags = kcTags.map((tag) => tag.split('/').pop());
   const title = getMetadata('og:title');
 
-  const chapterItems = await ffetch('/en-us/related-articles-index.json')
+  const chapterItems = await ffetch('/eds/related-articles-index.json')
     .filter((item) => item.title && item.title !== title)
     .filter((item) => item.tags && extractedTags.some((tag) => item.tags.includes(tag)))
     .all();

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -28,7 +28,7 @@ indices:
       - /en-us/technical-resources/protocols/query-index.json
       - /en-us/knowledge-center/query-index.json
       - /en-us/webinars/query-index.json
-    target: /en-us/related-articles-index.json
+    target: /eds/related-articles-index.json
     properties:
       title:
         select: head > meta[property="og:title"]


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #596 

Test URLs:
Before: https://main--danaher-abcam--aemsites.hlx.page/en-us/knowledge-center/cell-biology/sodium-azide
After: https://596-related-articles--danaher-abcam--aemsites.hlx.page/en-us/knowledge-center/cell-biology/sodium-azide
